### PR TITLE
postgis: ruffを導入

### DIFF
--- a/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
+++ b/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
@@ -13,9 +13,10 @@ genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
 # MCP 設定
 server_params = StdioServerParameters(
     command="uv",  # Executable
-    args=["run","infrastructure/mcp/chat_repository.py"],
-     env=None,  # Optional environment variables
+    args=["run", "infrastructure/mcp/chat_repository.py"],
+    env=None,  # Optional environment variables
 )
+
 
 @router.post("/chat")
 async def chat_request(request: Request):
@@ -32,7 +33,4 @@ async def chat_request(request: Request):
     gemini_response = model.generate_content(f"以下のデータをわかりやすく説明してください：\n{mcp_response}")
     explanation = gemini_response.text
 
-    return {
-        "tool_result": mcp_response,
-        "gemini_summary": explanation
-    }
+    return {"tool_result": mcp_response, "gemini_summary": explanation}

--- a/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
+++ b/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Request
-from mcp.client.stdio import stdio_client
-from mcp import ClientSession, StdioServerParameters
-from google import generativeai as genai
 import os
+
+from fastapi import APIRouter, Request
+from google import generativeai as genai
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
 
 router = APIRouter()
 

--- a/03_プロトタイプ/postgis/backend/controller/train/train_controller.py
+++ b/03_プロトタイプ/postgis/backend/controller/train/train_controller.py
@@ -1,5 +1,7 @@
-from fastapi import APIRouter, Request
 from urllib.parse import unquote
+
+from fastapi import APIRouter, Request
+
 from infrastructure.database.train.train_repository import TrainRepository
 
 router = APIRouter()
@@ -11,7 +13,7 @@ async def get_all_stations(request: Request):
 
 @router.get("/train/station/{station_name}")
 async def get_station_by_name(station_name: str, request: Request):
-    decoded_name = unquote(station_name)  
+    decoded_name = unquote(station_name)
     return await train_repository.get_station_by_name(decoded_name, request)
 
 @router.get("/train/line")

--- a/03_プロトタイプ/postgis/backend/controller/train/train_controller.py
+++ b/03_プロトタイプ/postgis/backend/controller/train/train_controller.py
@@ -7,18 +7,22 @@ from infrastructure.database.train.train_repository import TrainRepository
 router = APIRouter()
 train_repository = TrainRepository()
 
+
 @router.get("/train/station")
 async def get_all_stations(request: Request):
     return await train_repository.get_all_stations(request)
+
 
 @router.get("/train/station/{station_name}")
 async def get_station_by_name(station_name: str, request: Request):
     decoded_name = unquote(station_name)
     return await train_repository.get_station_by_name(decoded_name, request)
 
+
 @router.get("/train/line")
 async def get_all_lines(request: Request):
     return await train_repository.get_all_lines(request)
+
 
 @router.get("/train/line/{line_name}")
 async def get_line_by_name(line_name: str, request: Request):

--- a/03_プロトタイプ/postgis/backend/infrastructure/database/train/train_repository.py
+++ b/03_プロトタイプ/postgis/backend/infrastructure/database/train/train_repository.py
@@ -68,11 +68,11 @@ class TrainRepository:
         WHERE "n05_002" = $1
         """
         async with request.app.state.pool.acquire() as conn:
-          rows = await conn.fetch(query, line_name)
-          if not rows:
-              raise HTTPException(status_code=404, detail=f"Line not found: {line_name}")
+            rows = await conn.fetch(query, line_name)
+            if not rows:
+                raise HTTPException(status_code=404, detail=f"Line not found: {line_name}")
 
-          # 🔑 ここで json.loads して「文字列 → オブジェクト」に変換
-          features = [json.loads(r["geojson"]) for r in rows]
+            # 🔑 ここで json.loads して「文字列 → オブジェクト」に変換
+            features = [json.loads(r["geojson"]) for r in rows]
 
-          return {"type": "FeatureCollection", "features": features}
+            return {"type": "FeatureCollection", "features": features}

--- a/03_プロトタイプ/postgis/backend/infrastructure/database/train/train_repository.py
+++ b/03_プロトタイプ/postgis/backend/infrastructure/database/train/train_repository.py
@@ -1,5 +1,7 @@
 import json
-from fastapi import Request, HTTPException
+
+from fastapi import HTTPException, Request
+
 
 class TrainRepository:
     async def get_all_stations(self, request: Request):
@@ -36,7 +38,7 @@ class TrainRepository:
             if result:
                 return result["geojson"]
             raise HTTPException(status_code=404, detail="Station not found")
-        
+
     async def get_all_lines(self, request: Request):
         query = """
         SELECT jsonb_build_object(
@@ -54,7 +56,7 @@ class TrainRepository:
         async with request.app.state.pool.acquire() as conn:
             result = await conn.fetchrow(query)
             return result["geojson"]
-        
+
     async def get_line_by_name(self, line_name: str, request: Request):
         query = """
         SELECT jsonb_build_object(

--- a/03_プロトタイプ/postgis/backend/infrastructure/mcp/chat_repository.py
+++ b/03_プロトタイプ/postgis/backend/infrastructure/mcp/chat_repository.py
@@ -1,5 +1,6 @@
-from infrastructure.database.train.train_repository import TrainRepository
 from mcp.server.fastmcp import FastMCP
+
+from infrastructure.database.train.train_repository import TrainRepository
 
 mcp = FastMCP("chat-server")
 train_repository = TrainRepository()

--- a/03_プロトタイプ/postgis/backend/infrastructure/mcp/chat_repository.py
+++ b/03_プロトタイプ/postgis/backend/infrastructure/mcp/chat_repository.py
@@ -5,11 +5,13 @@ from infrastructure.database.train.train_repository import TrainRepository
 mcp = FastMCP("chat-server")
 train_repository = TrainRepository()
 
+
 @mcp.tool()
 def get_station_by_name(station_name: str):
     """駅名を指定して駅情報を取得します。"""
     station_geojson = train_repository.get_station_by_name(station_name)
     return station_geojson
+
 
 @mcp.tool()
 def get_train_line_by_name(line_name: str):

--- a/03_プロトタイプ/postgis/backend/main.py
+++ b/03_プロトタイプ/postgis/backend/main.py
@@ -20,6 +20,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 # DB接続プール
 @app.on_event("startup")
 async def startup():
@@ -31,13 +32,16 @@ async def startup():
         port=int(os.getenv("PGPORT", 5432)),
     )
 
+
 @app.on_event("shutdown")
 async def shutdown():
     await app.state.pool.close()
 
+
 @app.get("/")
 async def root():
     return {"message": "hello"}
+
 
 # ルーター登録
 app.include_router(train_router)

--- a/03_プロトタイプ/postgis/backend/main.py
+++ b/03_プロトタイプ/postgis/backend/main.py
@@ -1,12 +1,14 @@
 # main.py
 
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-import asyncpg
 import os
 
-from controller.train.train_controller import router as train_router
+import asyncpg
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
 from controller.chat.chat_controller import router as chat_router
+from controller.train.train_controller import router as train_router
+
 app = FastAPI()
 
 # CORS設定

--- a/03_プロトタイプ/postgis/backend/pyproject.toml
+++ b/03_プロトタイプ/postgis/backend/pyproject.toml
@@ -13,4 +13,31 @@ dependencies = [
 ]
 
 [tool.uv]
-dev-dependencies = []
+dev-dependencies = [
+    "ruff>=0.12.7",
+]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "UP", # pyupgrade
+]
+ignore = [
+    "E501", # line too long, handled by ruff format
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"


### PR DESCRIPTION
### 概要
- Python 用リンター兼フォーマッタ の `Ruff` を導入

- 設定内容は、`pyproject.toml` の以下の部分

```toml
[tool.ruff]
target-version = "py311"
line-length = 120


[tool.ruff.lint]
select = [
    "E",  # pycodestyle errors
    "W",  # pycodestyle warnings
    "F",  # pyflakes
    "I",  # isort
    "B",  # flake8-bugbear
    "C4", # flake8-comprehensions
    "UP", # pyupgrade
]
ignore = [
    "E501", # line too long, handled by ruff format
]

[tool.ruff.format]
quote-style = "double"
indent-style = "space"
skip-magic-trailing-comma = false
line-ending = "auto"
```

### 使い方
backendに移動する
```bash
cd 03_プロトタイプ/postgis/backend
```

lintを実行
```bash
uv run ruff check --fix .
```

formatを実行
```bash
uv run ruff format . 
```

VSCode拡張を入れるとより便利になるはず
識別子: `charliermarsh.ruff`