### PR TITLE
Geminiに関数を実行させずに関数の選択だけさせる

### DIFF
--- a/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
+++ b/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
@@ -38,9 +38,23 @@ async def chat_request(request: ChatRequest):
                             "ツールから返された結果をそのまま返答として使ってください。"
                         ),
                         tools=[session],
+                        automatic_function_calling=genai.types.AutomaticFunctionCallingConfig(disable=True),
                     ),
                     contents=request.message,
                 )
+                try:
+                    part = response.candidates[0].content.parts[0]
+                except Exception:
+                    part = None
+
+                if part and hasattr(part, "function_call") and part.function_call:
+                    fn = part.function_call.name
+                    args = dict(part.function_call.args or {})
+
+                    # MCPツールを実行
+                    tool_result = await session.call_tool(fn, args)
+
+                    return {"response": str(tool_result.content[0].text)}
 
         return {"response": response.text}
 

--- a/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
+++ b/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
@@ -41,6 +41,7 @@ async def chat_request(request: ChatRequest):
                             """
                         ),
                         tools=[session],
+                        # MCPツールを実行しないようにする
                         automatic_function_calling=genai.types.AutomaticFunctionCallingConfig(disable=True),
                     ),
                     contents=request.message,

--- a/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
+++ b/03_プロトタイプ/postgis/backend/controller/chat/chat_controller.py
@@ -31,11 +31,14 @@ async def chat_request(request: ChatRequest):
                     model="gemini-2.5-flash",
                     config=types.GenerateContentConfig(
                         system_instruction=(
-                            "ユーザーが鉄道路線の名前（例: 池袋線、山手線）を入力した場合、"
-                            "`get_line_by_name` ツールを必ず使用してください。"
-                            "ユーザーが駅の名前（例: 東京、池袋）を入力した場合、"
-                            "`get_station_by_name` ツールを必ず使用してください。"
-                            "ツールから返された結果をそのまま返答として使ってください。"
+                            """
+                            あなたは鉄道の情報を取得するツールの実行に特化したAIです。
+                            ユーザーが鉄道路線の名前（例: 池袋線、山手線）を入力した場合、
+                            `get_line_by_name` ツールを必ず使用してください。
+                            ユーザーが駅の名前（例: 東京、池袋）を入力した場合、
+                            `get_station_by_name` ツールを必ず使用してください。
+                            使用すべきツールがわからない場合は必ず、「駅名または路線名を入力してください。」と返答してください。
+                            """
                         ),
                         tools=[session],
                         automatic_function_calling=genai.types.AutomaticFunctionCallingConfig(disable=True),


### PR DESCRIPTION
### 概要
- Geminiに関数を実行させずに関数の選択だけさせる

  - Geminiに使用すべき関数と引数を教えてもらい、それをコードで実行する

- mcpツールの実行結果を、Geminiに入力・出力させないことにより以下のメリットがある

  - 実行が一瞬になる

  - トークン使用量の大幅な削減

- 参考

  - [MCPホストをGeminiで自作してみた！]( https://qiita.com/hirao_takamichi/items/d1cf9d5e29c1a44e7d94#mcp%E3%83%9B%E3%82%B9%E3%83%88%E3%82%AF%E3%83%A9%E3%82%A4%E3%82%A2%E3%83%B3%E3%83%88%E3%81%AE%E6%A9%9F%E8%83%BD%E3%82%82%E6%90%AD%E8%BC%89)